### PR TITLE
Create provider.tf

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.11.0"
+    }
+  }
+}
+
+provider "aws" {
+  # Configuration options
+  region = "us-east-1"
+}


### PR DESCRIPTION
For creating a VPC we need to provide the provider.tf which will describe the cloud provider we are using and the required version.